### PR TITLE
fix: force proxy for web player

### DIFF
--- a/addon/addon.js
+++ b/addon/addon.js
@@ -412,7 +412,7 @@ builder.defineStreamHandler(async (args) => {
             isLive: true,
             bingeGroup: `nzfreeview-${channelId}`,
             // Transport hints
-            notWebReady: false, // Allow web player to handle HLS directly
+            notWebReady: true, // Force proxying for web player
             isHLS: true, // Indicate this is an HLS stream
             isCORSRequired: true,
             player: 'hls',  // Force HLS player


### PR DESCRIPTION
Sets `notWebReady` to `true` in the stream's `behaviorHints`. This forces the Stremio web player to use the addon's streaming server, which correctly proxies the stream with the required headers, fixing playback in cloud environments.