### PR TITLE
fix: add proxyHeaders to force correct stream handling

### DIFF
--- a/addon/addon.js
+++ b/addon/addon.js
@@ -412,11 +412,16 @@ builder.defineStreamHandler(async (args) => {
             isLive: true,
             bingeGroup: `nzfreeview-${channelId}`,
             // Transport hints
-            notWebReady: false, // Allow web player to handle HLS directly
+            notWebReady: true, // Force proxying for web player
             isHLS: true, // Indicate this is an HLS stream
             isCORSRequired: true,
             player: 'hls',  // Force HLS player
-            subtitlesForDirectPlayback: false
+            subtitlesForDirectPlayback: false,
+            proxyHeaders: {
+                "request": {
+                    ...streamHeaders
+                }
+            }
         }
     };
     


### PR DESCRIPTION
Adds the `proxyHeaders` property to the `behaviorHints` object in the stream response. This, in conjunction with `notWebReady: true`, ensures that the Stremio client (including the web player) uses the addon's proxy and sends the correct headers for the stream.

This should resolve the "no viable transport found" and "Video is not supported" errors in cloud-deployed environments.