### PR TITLE
fix: comprehensive fix for streaming errors

### DIFF
--- a/addon/addon.js
+++ b/addon/addon.js
@@ -43,7 +43,7 @@ const PORT = process.env.PORT || 8080;
 // The addon's public host URL. This is critical for generating absolute stream URLs.
 // It's automatically detected from Google Cloud Run's K_SERVICE_URL environment variable.
 // If deploying elsewhere, the ADDON_HOST environment variable must be set manually.
-const ADDON_HOST = process.env.K_SERVICE_URL || process.env.ADDON_HOST;
+const ADDON_HOST = (process.env.K_SERVICE_URL || process.env.ADDON_HOST || '').replace(/^http:\/\//, 'https://');
  
 if (!ADDON_HOST) {
     log('ERROR', 'CONFIG', 'CRITICAL: Addon host URL is not configured. Set K_SERVICE_URL or ADDON_HOST.');
@@ -412,7 +412,7 @@ builder.defineStreamHandler(async (args) => {
             isLive: true,
             bingeGroup: `nzfreeview-${channelId}`,
             // Transport hints
-            notWebReady: false, // Allow web player to handle HLS directly
+            notWebReady: true, // Force proxying for web player
             isHLS: true, // Indicate this is an HLS stream
             isCORSRequired: true,
             player: 'hls',  // Force HLS player

--- a/server.js
+++ b/server.js
@@ -23,8 +23,7 @@ app.use((req, res, next) => {
         'https://web.stremio.com',
         'https://app.strem.io',
         'https://stremio.github.io',
-        'http://127.0.0.1:11470',
-        'http://localhost:11470'
+        'https://nz-freeview-addon-355637409766.us-west1.run.app'
     ];
     
     // Allow specific origins for Stremio web player
@@ -188,7 +187,7 @@ const proxyHandler = async (req, res) => {
         // HLS manifest: rewrite segment URLs to go through our proxy
         if (isM3U8) {
             let m3u8Body = await upstreamRes.text();
-            const addonBaseUrl = process.env.K_SERVICE_URL || process.env.ADDON_HOST || `${req.protocol}://${req.get('host')}`;
+            const addonBaseUrl = (process.env.K_SERVICE_URL || process.env.ADDON_HOST || `${req.protocol}://${req.get('host')}`).replace(/^http:\/\//, 'https://');
             const rewrittenLines = m3u8Body.split('\n').map(line => {
                 line = line.trim();
                 if (line && !line.startsWith('#')) {


### PR DESCRIPTION
This commit includes a comprehensive set of fixes to address the long-running streaming errors:

- **`server.js`:**
  - Corrects the `allowedOrigins` for production.
  - Ensures the proxy rewrites HLS playlist URLs with `https`.
- **`addon/addon.js`:**
  - Forces `ADDON_HOST` to `https`.
  - Sets `notWebReady: true` to ensure the proxy is used.

These changes should finally resolve the "no viable transport found" and "Video is not supported" errors in all Stremio clients.