### PR TITLE
fix: Remove node-fetch and rely on global fetch

### DIFF
--- a/addon/addon.js
+++ b/addon/addon.js
@@ -1,5 +1,4 @@
 const { addonBuilder } = require('stremio-addon-sdk');
-const fetch = require('node-fetch');
 
 // Enhanced logging system for production debugging
 const LOG_LEVELS = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "node-fetch": "^2.7.0",
         "stremio-addon-sdk": "^1.6.10"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "node-fetch": "^2.7.0",
     "stremio-addon-sdk": "^1.6.10"
   },
   "engines": {

--- a/server.js
+++ b/server.js
@@ -2,8 +2,6 @@ const express = require('express');
 const path = require('path');
 const { getRouter } = require('stremio-addon-sdk');
 const addonInterface = require('./addon/addon.js');
-const AbortController = require('abort-controller');
-const fetch = require('node-fetch');
 
 // Read version from package.json to have a single source of truth
 const { version } = require('./package.json');


### PR DESCRIPTION
This commit removes the `node-fetch` dependency and updates the code to use the global `fetch` and `AbortController` available in Node.js 18+.

This change is intended to fix a deployment issue where the container fails to start. By removing the dependency, we eliminate potential compatibility issues between `node-fetch` and the Node.js environment.